### PR TITLE
Delete admin accounts as admin

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -12,7 +12,8 @@ var User = new Schema({
     tier: String,
     photoUrl: String,
     stripeId: String,
-    subscriptionId: String
+    subscriptionId: String,
+    isAdmin: Boolean
 });
 
 User.plugin(passportLocalMongoose);

--- a/routes/account.js
+++ b/routes/account.js
@@ -165,4 +165,23 @@ module.exports = function(app) {
     app.get('/account/password_reset', function(req, res, next) {
         res.render('account/reset_password');
     });
+
+    app.delete('/account', function(req, res, next) {
+        var username = req.body.username;
+
+        if (req.user && req.user.isAdmin) {
+            User.findOneAndRemove({username: username}, function(err, user) {
+              if (err) {
+                console.log('error removing user account', err);
+                res.sendStatus(500);
+                return;
+              }
+
+              // deleted successfully
+              res.sendStatus(200);
+            });
+        } else {
+            res.sendStatus(403);
+        }
+    });
 };


### PR DESCRIPTION
One of the other tasks for this user story is creating user accounts as an admin, but this is already achievable through the '/signup' route, so not adding anything more.
